### PR TITLE
fix: avoid unlimited routing

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,8 +2,8 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { checkSession } from './features/auth'
 
-const AUTH_PAGES = ['/login', '/register', '/logout'] as const
-const PROTECTED_PAGES = ['/dashboard'] as const
+const AUTH_PAGES = ['/login', '/register'] as const
+const PROTECTED_PAGES = ['/dashboard', '/logout'] as const
 
 function requestMatchPaths(req: NextRequest, paths: readonly string[]) {
   return paths.some((p) => req.nextUrl.pathname.startsWith(p))
@@ -23,7 +23,7 @@ export async function middleware(req: NextRequest) {
     return NextResponse.redirect(new URL('/login', req.url))
   }
 
-  if (requestMatchPaths(req, AUTH_PAGES) && !(await isAlreadyLogin(req))) {
+  if (requestMatchPaths(req, AUTH_PAGES) && (await isAlreadyLogin(req))) {
     return NextResponse.redirect(new URL('/dashboard', req.url))
   }
 


### PR DESCRIPTION
access `/logout` only if already login

if visit AUTH_PAGES and isAlreadyLogin, just route to `/dashboard`